### PR TITLE
Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ There is one small config to be done in `/etc/salt/master`, add the salt formula
     gitfs_remotes:
       - git://github.com/saltstack-formulas/salt-formula.git
 
+You may also want to setup the roles for your devices, using the example under `nodes` in `pillar.example`
+
 Then run the orchestration with:
 
     $ ./orchestrate

--- a/README.md
+++ b/README.md
@@ -10,4 +10,19 @@ There is one small config to be done in `/etc/salt/master`, add the salt formula
 
 Then run the orchestration with:
 
-    $ sudo ./orchestrate
+    $ ./orchestrate
+
+Upgrading an Existing Minion
+============================
+
+To find the versions of all minions:
+
+    $ ./versions
+
+For old minions, you can upgrade them with:
+
+    $ sudo salt 'host' state.sls bootstrap
+
+This won't return properly, but it should work, to confirm:
+
+    $ ./versions

--- a/bootstrap.sls
+++ b/bootstrap.sls
@@ -1,0 +1,3 @@
+minion-bootstrap:
+  cmd.run:
+    - name: wget -O - https://bootstrap.saltstack.com | sudo sh

--- a/grains.sls
+++ b/grains.sls
@@ -1,0 +1,9 @@
+include:
+  - salt.minion
+
+/etc/salt/grains:
+  file.managed:
+    - template: jinja
+    - source: salt://salt/files/grains
+    - watch_in:
+      - service: salt-minion

--- a/orchestrate
+++ b/orchestrate
@@ -3,4 +3,4 @@ test=""
 if [ "$1" = "test" ]; then
     test="test=True"
 fi
-eval "salt-run state.orchestrate orchestration.salt $test"
+eval "sudo salt-run state.orchestrate orchestration.salt $test"

--- a/orchestration/salt.sls
+++ b/orchestration/salt.sls
@@ -13,3 +13,11 @@ salt-minion:
       - salt.pkgrepo
     - require:
       - salt: salt-master
+
+salt-minion-grains:
+  salt.state:
+    - tgt: '*'
+    - sls:
+      - grains
+    - require:
+      - salt: salt-minion

--- a/pillar.example
+++ b/pillar.example
@@ -26,3 +26,9 @@ salt:
       ssl_key: '/etc/pki/tls/certs/localhost.key'
   minion:
     master: salt
+
+nodes:
+  myhost:
+    roles:
+      - server
+      - salt-master

--- a/salt/files/grains
+++ b/salt/files/grains
@@ -1,0 +1,9 @@
+{% set host = grains['id'] -%}
+{% set roles = salt['pillar.get']('nodes:' + host + ':roles',[]) -%}
+
+{% if roles -%}
+role:
+  {% for role in roles -%}
+  - {{ role }}
+  {% endfor -%}
+{% endif -%}

--- a/versions
+++ b/versions
@@ -1,0 +1,2 @@
+#!/bin/bash
+eval "sudo salt-run manage.versions"


### PR DESCRIPTION
Add roles to the `/etc/salt/grains` file on each minion, which are then provided in the grains for each minion for targeting purposes.
